### PR TITLE
Fixed minor bug in getAttributeSplice.

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -1,5 +1,5 @@
 name:           heist
-version:        0.8.0
+version:        0.8.0.1
 synopsis:       An (x)html templating system
 description:    An (x)html templating system
 license:        BSD3

--- a/src/Text/Templating/Heist/Internal.hs
+++ b/src/Text/Templating/Heist/Internal.hs
@@ -446,8 +446,9 @@ attParser = liftM ($! []) (loop id)
 getAttributeSplice :: Monad m => Text -> HeistT m Text
 getAttributeSplice name = do
     s <- liftM (lookupSplice name) getTS
-    nodes <- maybe (return []) id s
+    nodes <- maybe (return []) withAttrParamNode s
     return $ T.concat $ map X.nodeText nodes
+  where withAttrParamNode = localParamNode (const (X.Element name [] []))
 
 ------------------------------------------------------------------------------
 -- | Performs splice processing on a list of nodes.


### PR DESCRIPTION
Hey guys. It seemed that the paramNode when running splices in attributes wasn't (re)set correctly causing infinte loops in some cases. I've made a patch that sets the paramNode to a fake empty node with the name of the splice currently being processed.

Can you maybe review the code and apply when you think this is the right way to do this?

Thanks!
