### PR TITLE
relax MonadCatchIO-transformers and mtl deps

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Edward Kmett
 Will Langstroth <will@langstroth.com>
 Shane O'Brien <shane@duairc.com>
 James Sanders <jimmyjazz14@gmail.com>
+Mark Wright <gienah@gentoo.org>

--- a/heist.cabal
+++ b/heist.cabal
@@ -88,7 +88,7 @@ Library
     attoparsec                >= 0.10  && < 0.11,
     base                      >= 4     && < 5,
     blaze-builder             >= 0.2   && < 0.4,
-    blaze-html                >= 0.4   && < 0.5,
+    blaze-html                >= 0.4   && < 0.6,
     bytestring,
     containers                >= 0.2   && < 0.5,
     directory,


### PR DESCRIPTION
heist 0.8.0 builds fine with the MonadCatchIO-transformers and mtl deps relaxed.
