### PR TITLE
Remove swp files

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -61,8 +61,6 @@ extra-source-files:
   test/suite/Heist/Interpreted/Tests.hs,
   test/suite/Heist/TestCommon.hs,
   test/suite/Heist/Tests.hs,
-  test/suite/Heist/Tutorial/.AttributeSplices.lhs.swp,
-  test/suite/Heist/Tutorial/.CompiledSplices.lhs.swp,
   test/suite/Heist/Tutorial/AttributeSplices.lhs,
   test/suite/Heist/Tutorial/CompiledSplices.lhs,
   test/suite/Heist/Tutorial/Imports.hs,


### PR DESCRIPTION
I'm guessing these swp files weren't meant to be put in the cabal file.
