### PR TITLE
Don't render tags as 'self-closing' when not allowed.

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -157,7 +157,7 @@ Library
     time                       >= 1.1     && < 1.5,
     unordered-containers       >= 0.1.4   && < 0.3,
     vector                     >= 0.9     && < 0.11,
-    xmlhtml                    >= 0.1.6   && < 0.3
+    xmlhtml                    >= 0.2.1   && < 0.3
 
   if impl(ghc >= 6.12.0)
     ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2

--- a/src/Heist/Compiled/Internal.hs
+++ b/src/Heist/Compiled/Internal.hs
@@ -21,6 +21,7 @@ import           Data.ByteString (ByteString)
 import           Data.DList                      (DList)
 import qualified Data.DList                      as DL
 import qualified Data.HashMap.Strict             as H
+import qualified Data.HashSet                    as S
 import qualified Data.HeterogeneousEnvironment   as HE
 import           Data.Maybe
 import           Data.Text                       (Text)
@@ -29,6 +30,7 @@ import qualified Data.Text.Encoding              as T
 import qualified Data.Vector                     as V
 import           Prelude                         hiding (catch)
 import qualified Text.XmlHtml                    as X
+import qualified Text.XmlHtml.HTML.Meta          as X
 ------------------------------------------------------------------------------
 import           Heist.Common
 import           Heist.Types
@@ -429,7 +431,7 @@ compileNode (X.Element nm attrs ch) =
 
         childHtml <- runNodeList ch
 
-        return $! if null (DL.toList childHtml)
+        return $! if null (DL.toList childHtml) && nm `S.member` X.voidTags
           then DL.concat [ DL.singleton $! pureTextChunk $! tag0
                          , DL.concat compiledAttrs
                          , DL.singleton $! pureTextChunk " />"


### PR DESCRIPTION
Only some tags, like 'br' and 'img', can be "self-closing" in HTML5.
These are not actually self-closing: `<br />` means the same as
`<br>`. But e.g. `<a></a>` means something completely different from
`<a>`, so it should not render this way, even if it has no children.

This fixes #29.
