### PR TITLE
Allow indexed access to JSON arrays.

### DIFF
--- a/src/Heist/Splices/Json.hs
+++ b/src/Heist/Splices/Json.hs
@@ -98,7 +98,10 @@ findExpr t = go (T.split (=='.') t)
     go (x:xs) !value = findIn value >>= go xs
       where
         findIn (Object obj) = Map.lookup x obj
+        findIn (Array arr)  = tryReadIndex >>= \i -> arr V.!? i
         findIn _            = Nothing
+
+        tryReadIndex = fmap fst . listToMaybe . reads . T.unpack $ x
 
 
 ------------------------------------------------------------------------------

--- a/test/templates/json_array.tpl
+++ b/test/templates/json_array.tpl
@@ -1,0 +1,1 @@
+<jsonArray><value var="ctx.0"/>, <value var="ctx.1"/> and <with var="ctx.2"><value:deep/> <value:inside/></with></jsonArray>


### PR DESCRIPTION
Limited but useful acess to Haskell tuples represented as arrays in JSON:

```XML
<thingy>
    <value var="foo.1.bar"/>
</thingy>
```