### PR TITLE
Clean up and explicitify top-level imports.

### DIFF
--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -1,28 +1,29 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Heist.Common where
 
-import           Control.Applicative
-import           Control.Exception (SomeException)
-import           Control.Monad
-import qualified Control.Monad.CatchIO as C
-import qualified Data.Attoparsec.Text            as AP
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as B
+import           Control.Applicative   (Alternative (..), Applicative (..),
+                                        (<$>))
+import           Control.Exception     (SomeException)
+import           Control.Monad         (liftM, mplus)
+import qualified Control.Monad.CatchIO as C (catch)
+import qualified Data.Attoparsec.Text  as AP
+import           Data.ByteString       (ByteString)
+import qualified Data.ByteString       as B
 import qualified Data.ByteString.Char8 as BC
-import           Data.Hashable
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as Map
-import           Data.List
-import           Data.Maybe
-import           Data.Monoid
-import qualified Data.Text                       as T
-import           System.FilePath
-import           Heist.SpliceAPI
+import           Data.Hashable         (Hashable)
+import           Data.HashMap.Strict   (HashMap)
+import qualified Data.HashMap.Strict   as Map
+import           Data.List             (isSuffixOf)
+import           Data.Maybe            (isJust)
+import           Data.Monoid           (Monoid (..))
+import qualified Data.Text             as T
+import           Heist.SpliceAPI       (Splices, splicesToList)
 import           Heist.Types
-import qualified Text.XmlHtml as X
+import           System.FilePath       (pathSeparator)
+import qualified Text.XmlHtml          as X
 
 
 ------------------------------------------------------------------------------

--- a/src/Heist/SpliceAPI.hs
+++ b/src/Heist/SpliceAPI.hs
@@ -25,13 +25,13 @@ Here's how you can define splices:
 
 module Heist.SpliceAPI where
 
-import           Control.Applicative
-import           Control.Monad.State (State, MonadState, execState, modify)
-import           Data.Map (Map)
-import qualified Data.Map as M
-import           Data.Monoid
-import           Data.Text (Text)
-import qualified Data.Text as T
+import           Control.Applicative (Applicative)
+import           Control.Monad.State (MonadState, State, execState, modify)
+import           Data.Map            (Map)
+import qualified Data.Map            as M
+import           Data.Monoid         (Monoid (..))
+import           Data.Text           (Text)
+import qualified Data.Text           as T
 
 
 ------------------------------------------------------------------------------
@@ -106,7 +106,7 @@ add m = modify (\s -> M.unionWith (\_ b -> b) s m)
 ------------------------------------------------------------------------------
 -- | Maps a function over all the splices.
 mapS :: (a -> b) -> Splices a -> Splices b
-mapS f ss = add $ M.map f $ runSplices ss 
+mapS f ss = add $ M.map f $ runSplices ss
 
 
 ------------------------------------------------------------------------------

--- a/src/Heist/Splices.hs
+++ b/src/Heist/Splices.hs
@@ -9,7 +9,7 @@ module Heist.Splices
   , module Heist.Splices.Markdown
   ) where
 
-import           Data.Monoid
+import           Data.Monoid (Monoid(..))
 import qualified Heist.Compiled as C
 import qualified Heist.Interpreted as I
 import           Heist.Splices.Apply

--- a/src/Heist/Types.hs
+++ b/src/Heist/Types.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 {-|
 
@@ -18,32 +18,34 @@ liberating us from the unused writer portion of RWST.
 module Heist.Types where
 
 ------------------------------------------------------------------------------
-import           Blaze.ByteString.Builder
-import           Control.Applicative
-import           Control.Arrow
-import           Control.Monad.CatchIO (MonadCatchIO)
-import qualified Control.Monad.CatchIO as C
-import           Control.Monad.Cont
-import           Control.Monad.Error
-import           Control.Monad.Reader
-import           Control.Monad.State.Strict
-import           Data.ByteString.Char8 (ByteString)
-import           Data.DList                      (DList)
-import qualified Data.HashMap.Strict as H
-import           Data.HashMap.Strict (HashMap)
-import           Data.HeterogeneousEnvironment   (HeterogeneousEnvironment)
+import           Blaze.ByteString.Builder      (Builder)
+import           Control.Applicative           (Alternative (..),
+                                                Applicative (..), (<$>))
+import           Control.Arrow                 (first)
+import           Control.Monad                 (MonadPlus (..), ap)
+import           Control.Monad.CatchIO         (MonadCatchIO)
+import qualified Control.Monad.CatchIO         as C
+import           Control.Monad.Cont            (MonadCont (..))
+import           Control.Monad.Error           (MonadError (..))
+import           Control.Monad.Fix             (MonadFix (..))
+import           Control.Monad.Reader          (MonadReader (..))
+import           Control.Monad.State.Strict    (MonadState (..), StateT)
+import           Control.Monad.Trans           (MonadIO (..), MonadTrans (..))
+import           Data.ByteString.Char8         (ByteString)
+import           Data.DList                    (DList)
+import           Data.HashMap.Strict           (HashMap)
+import qualified Data.HashMap.Strict           as H
+import           Data.HeterogeneousEnvironment (HeterogeneousEnvironment)
 import qualified Data.HeterogeneousEnvironment as HE
-import           Data.Monoid
-import           Data.Text (Text)
-import qualified Data.Text as T
-import           Data.Text.Encoding
-import           Data.Typeable
-import qualified Text.XmlHtml as X
+import           Data.Monoid                   (Monoid(..))
+import           Data.Text                     (Text)
+import qualified Data.Text                     as T
+import           Data.Text.Encoding            (decodeUtf8)
+import           Data.Typeable                 (TyCon, Typeable(..),
+                                                Typeable1(..), mkTyCon,
+                                                mkTyConApp)
+import qualified Text.XmlHtml                  as X
 
-import Debug.Trace
-
-tr :: Show a => String -> a -> a
-tr s x = trace (s++show x) x
 
 ------------------------------------------------------------------------------
 -- | A 'Template' is a forest of XML nodes.  Here we deviate from the \"single


### PR DESCRIPTION
All modified files are now also completely prettified via stylish-haskell. Requested during Hac NYC. Note that `cabal configure --ghc-option=-ddump-minimal-imports` may make explicit imports redundant. Still useful changes included: removing old debug code in `Types.hs`.
