### PR TITLE
Fix for text 1.2.0.0

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -156,7 +156,7 @@ Library
     mtl                        >= 2.0     && < 2.3,
     process                    >= 1.1     && < 1.3,
     random                     >= 1.0.1.0 && < 1.1,
-    text                       >= 0.10    && < 1.2,
+    text                       >= 0.10    && < 1.3,
     time                       >= 1.1     && < 1.5,
     transformers               >= 0.3     && < 0.5,
     transformers-base          >= 0.4     && < 0.5,


### PR DESCRIPTION
Heist seems to build just fine under text 1.2.0.0.
