### PR TITLE
Add customizable pandoc splice

### DIFF
--- a/src/Heist/Splices/Markdown.hs
+++ b/src/Heist/Splices/Markdown.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-| The \"markdown\" splice formats markdown content as HTML and inserts
 it into the document.
 
@@ -9,21 +10,101 @@ Otherwise the non-markup children of the tag are processed as markdown
 and converted to HTML.
 
 This splice requires that the \"pandoc\" executable is in your path.
+
+You can add custom pandoc splice with 'pandocSplice'. It is not limited to
+markdown input, and can process anything pandoc can.
+
+For example you can create a page with generated table of contents, using
+heist template as pandoc template.
+
+>  <!-- _wrap.tpl -->
+>  <html>
+>    <head> <title> <pageTitle/> </title> </head>
+>
+>    <div class="nav"> <pageToc/> </div>
+>    <apply-content/>
+>  </html>
+
+And pandoc template, which would bind @pageTitle@ and @pageToc@ splices and
+applies "_wrap" template.
+
+>  <!-- _pandoc.tpl -->
+>  <apply template="_wrap.tpl">
+>    <bind tag="pageTitle"> $title$</bind>
+>    <bind tag="pageToc"> $toc$</bind>
+>    $body$
+>  </apply>
+
+Bind splice pandoc splice. Set it to not wrap in div, or it will break html
+from _wrap.tpl
+
+>  splices = "docmarkdown" ## pandocSplice opts
+>    where
+>      opts = setPandocArgs  ["-S", "--no-wrap", "--toc"
+>                            , "--standalone"
+>                            , "--template", "_pandoc.tpl"
+>                            , "--html5"]
+>             $ setPandocWrapDiv Nothing
+>             $ defaultPandocOptions
+>
+
+And then use it to render your markdown file
+
+
+>  <!-- apidocs.tpl -->
+>  <DOCTYPE html>
+>  <html lang="en">
+>  <head>
+>    <link href="/static/css/site.css rel="stylesheet">
+>  </head>
+>  <body>
+>    <apply template="_navbar.tpl" />
+>    <docmarkdown file="apidocs.md"/>
+>  </body>
+
 -}
-module Heist.Splices.Markdown where
+module Heist.Splices.Markdown
+  (
+  -- * Exceptions
+    PandocMissingException
+  , MarkdownException
+  , NoMarkdownFileException
+  -- * Markdown Splice
+  , markdownTag
+  , markdownSplice
+  -- * Generic pandoc splice
+  , pandocSplice
+  -- ** Pandoc Options
+  , PandocOptions
+  , defaultPandocOptions
+  , setPandocExecutable
+  , setPandocArgs
+  , setPandocBaseDir
+  , setPandocWrapDiv
+  -- ** Lens for 'PandocOptions'
+  , pandocExecutable
+  , pandocArgs
+  , pandocBaseDir
+  , pandocWrapDiv
+  -- * Internal helper functions
+  , pandoc
+  , pandocBS
+  , readProcessWithExitCode'
+  ) where
 
 ------------------------------------------------------------------------------
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Char8 as BC
-import           Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import           Data.Maybe
+import           Control.Applicative             ((<$>))
 import           Control.Concurrent
 import           Control.Exception.Lifted
 import           Control.Monad
 import           Control.Monad.Trans
+import           Data.ByteString                 (ByteString)
+import qualified Data.ByteString                 as B
+import qualified Data.ByteString.Char8           as BC
+import           Data.Maybe                      (fromMaybe)
+import           Data.Text                       (Text)
+import qualified Data.Text                       as T
+import qualified Data.Text.Encoding              as T
 import           Data.Typeable
 import           System.Directory
 import           System.Exit
@@ -34,8 +115,8 @@ import           Text.XmlHtml
 
 ------------------------------------------------------------------------------
 import           Heist.Common
-import           Heist.Interpreted.Internal
 import           Heist.Internal.Types.HeistState
+import           Heist.Interpreted.Internal
 
 data PandocMissingException = PandocMissingException
    deriving (Typeable)
@@ -67,69 +148,156 @@ instance Show NoMarkdownFileException where
 
 instance Exception NoMarkdownFileException where
 
+--------------------------------------------------------------------------------
+
+data PandocOptions = PandocOptions
+     { _pandocExecutable :: FilePath
+     , _pandocArgs       :: [String]         -- ^ Arguments to pandoc
+     , _pandocBaseDir    :: Maybe FilePath   -- ^ Base directory for input files
+                                             --   defaults to template path
+     , _pandocWrapDiv    :: Maybe Text       -- ^ Wrap content in div with class
+     } deriving (Eq, Ord, Show)
+
+-- | Default options
+defaultPandocOptions :: PandocOptions
+defaultPandocOptions = PandocOptions "pandoc"
+                                     ["-S", "--no-wrap"]
+                                     Nothing
+                                     (Just "markdown")
+
+-- | Name of pandoc executable
+setPandocExecutable :: FilePath -> PandocOptions -> PandocOptions
+setPandocExecutable e opt = opt { _pandocExecutable = e }
+
+-- | Arguments passed to pandoc
+setPandocArgs :: [String] -> PandocOptions -> PandocOptions
+setPandocArgs args opt = opt { _pandocArgs = args }
+
+-- | Base directory for input files, defaults to current template dir
+setPandocBaseDir :: Maybe FilePath -> PandocOptions -> PandocOptions
+setPandocBaseDir bd opt = opt { _pandocBaseDir = bd }
+
+-- | Wrap pandoc output in div with class. Appends node attributes to
+--   div and appends class to ones specified on node.
+setPandocWrapDiv :: Maybe Text -> PandocOptions -> PandocOptions
+setPandocWrapDiv wd opt = opt { _pandocWrapDiv = wd }
+
+pandocExecutable :: Functor f =>
+     (FilePath -> f FilePath) -> PandocOptions -> f PandocOptions
+pandocExecutable f po = (\e -> po { _pandocExecutable = e})
+                       <$> f (_pandocExecutable po)
+
+pandocArgs :: Functor f =>
+     ([String] -> f [String]) -> PandocOptions -> f PandocOptions
+pandocArgs f po = (\a -> po { _pandocArgs = a}) <$> f (_pandocArgs po)
+
+pandocBaseDir :: Functor f =>
+     (Maybe FilePath -> f (Maybe FilePath)) -> PandocOptions -> f PandocOptions
+pandocBaseDir f po = (\b -> po {_pandocBaseDir = b }) <$> f (_pandocBaseDir po)
+
+pandocWrapDiv :: Functor f =>
+     (Maybe Text -> f (Maybe Text)) -> PandocOptions -> f PandocOptions
+pandocWrapDiv f po = (\w -> po {_pandocWrapDiv = w}) <$> f (_pandocWrapDiv po)
+
 ------------------------------------------------------------------------------
 -- | Default name for the markdown splice.
 markdownTag :: Text
 markdownTag = "markdown"
 
 ------------------------------------------------------------------------------
--- | Implementation of the markdown splice.
+-- | Default markdown splice with executable "pandoc" and options "-S --no-wrap"
 markdownSplice :: MonadIO m => Splice m
-markdownSplice = do
+markdownSplice= pandocSplice defaultPandocOptions
+
+-- | Implementation of the markdown splice.
+pandocSplice :: MonadIO m => PandocOptions -> Splice m
+pandocSplice PandocOptions{..} = do
     templateDir <- liftM (fmap takeDirectory) getTemplateFilePath
-    pdMD <- liftIO $ findExecutable "pandoc"
+    pdMD <- liftIO $ findExecutable _pandocExecutable
 
-    when (isNothing pdMD) $ liftIO $ throwIO PandocMissingException
-
+    pandocExe <- case pdMD of
+       Nothing -> liftIO $ throwIO PandocMissingException
+       Just pd -> return pd
+    let withDir tp = fromMaybe tp _pandocBaseDir
+        pandocFile f tp = pandocWith pandocExe _pandocArgs (withDir tp) f
     tree <- getParamNode
     (source,markup) <- liftIO $
         case getAttribute "file" tree of
             Just f  -> do
                 m <- maybe (liftIO $ throwIO NoMarkdownFileException )
-                           (\tp -> pandoc (fromJust pdMD) tp $ T.unpack f)
+                           (pandocFile (T.unpack f))
                            templateDir
                 return (T.unpack f,m)
             Nothing -> do
-                m <- pandocBS (fromJust pdMD) $ T.encodeUtf8 $ nodeText tree
+                m <- pandocWithBS pandocExe _pandocArgs $ T.encodeUtf8 $ nodeText tree
                 return ("inline_splice",m)
 
     let ee = parseHTML source markup
+        nodeAttrs = case tree of
+          Element _ a _ -> a
+          _ -> []
+        nodeClass = lookup "class" nodeAttrs
+        attrs = filter (\(name, _) -> name /= "class" && name /= "file") nodeAttrs
     case ee of
       Left e  -> throw $ MarkdownException
                        $ BC.pack ("Error parsing markdown output: " ++ e)
-      Right d -> return (docContent d)
+      Right d -> return $ wrapResult nodeClass attrs (docContent d)
+
+  where
+    wrapResult nodeClass attrs body = case _pandocWrapDiv of
+        Nothing -> body
+        Just cls -> let finalAttrs = ("class", appendClass nodeClass cls):attrs
+                    in [Element "div" finalAttrs  body]
+    appendClass Nothing cls = cls
+    appendClass (Just orig) cls = T.concat [orig, " ", cls]
 
 
 pandoc :: FilePath -> FilePath -> FilePath -> IO ByteString
 pandoc pandocPath templateDir inputFile = do
-    (ex, sout, serr) <- readProcessWithExitCode' pandocPath args ""
-
-    when (isFail ex) $ throw $ MarkdownException serr
+    sout <- pandocWith pandocPath args templateDir inputFile
     return $ BC.concat [ "<div class=\"markdown\">\n"
                          , sout
                          , "\n</div>" ]
 
   where
-    isFail ExitSuccess = False
-    isFail _           = True
-
-    args = [ "-S", "--no-wrap", templateDir </> inputFile ]
+    args = [ "-S", "--no-wrap"]
 
 
 pandocBS :: FilePath -> ByteString -> IO ByteString
 pandocBS pandocPath s = do
-    -- using the crummy string functions for convenience here
-    (ex, sout, serr) <- readProcessWithExitCode' pandocPath args s
-
-    when (isFail ex) $ throw $ MarkdownException serr
+    sout <- pandocWithBS pandocPath args s
     return $ BC.concat [ "<div class=\"markdown\">\n"
                        , sout
                        , "\n</div>" ]
 
   where
+    args = [ "-S", "--no-wrap" ]
+
+
+pandocWith :: FilePath -> [String] -> FilePath -> FilePath -> IO ByteString
+pandocWith path args templateDir inputFile = do
+    (ex, sout, serr) <- readProcessWithExitCode' path args' ""
+
+    when (isFail ex) $ throw $ MarkdownException serr
+    return sout
+
+  where
     isFail ExitSuccess = False
     isFail _           = True
-    args = [ "-S", "--no-wrap" ]
+
+    args' = args ++ [templateDir </> inputFile ]
+
+pandocWithBS :: FilePath -> [String] -> ByteString -> IO ByteString
+pandocWithBS pandocPath args s = do
+    -- using the crummy string functions for convenience here
+    (ex, sout, serr) <- readProcessWithExitCode' pandocPath args s
+
+    when (isFail ex) $ throw $ MarkdownException serr
+    return sout
+
+  where
+    isFail ExitSuccess = False
+    isFail _           = True
 
 
 -- a version of readProcessWithExitCode that does I/O properly
@@ -176,7 +344,3 @@ readProcessWithExitCode' cmd args input = do
     err <- readMVar errM
 
     return (ex, out, err)
-
-
-
-

--- a/test/templates/pandoc.tpl
+++ b/test/templates/pandoc.tpl
@@ -1,0 +1,1 @@
+<pandocnodiv file="test.md"/>

--- a/test/templates/pandocdiv.tpl
+++ b/test/templates/pandocdiv.tpl
@@ -1,0 +1,1 @@
+<pandocdiv file="test.md" id="pandoc" class="foo"/>


### PR DESCRIPTION
This can be bound to any tag and used to run pandoc with custom
parameters.

Check [Heist.Splice.Markdown](https://github.com/sopvop/heist/blob/customize-markdown/src/Heist/Splices/Markdown.hs#L13) for example usage.

You can run this with any pandoc input format, not just markdown.
