### PR TITLE
Remove dependency on errors, replace with the either package

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -148,7 +148,7 @@ Library
     directory                  >= 1.1     && < 1.3,
     directory-tree             >= 0.10    && < 0.13,
     dlist                      >= 0.5     && < 0.8,
-    errors                     >= 1.4     && < 1.5,
+    either                     >= 4.3     && < 4.5,
     filepath                   >= 1.3     && < 1.5,
     hashable                   >= 1.1     && < 1.3,
     lifted-base                >= 0.2     && < 0.3,

--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -82,11 +82,12 @@ module Heist
 
 
 ------------------------------------------------------------------------------
-import           Control.Error
 import           Control.Exception.Lifted
 import           Control.Monad.State
+import           Control.Monad.Trans.Either
 import           Data.ByteString               (ByteString)
 import qualified Data.ByteString               as B
+import           Data.Either
 import qualified Data.Foldable                 as F
 import           Data.HashMap.Strict           (HashMap)
 import qualified Data.HashMap.Strict           as Map

--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -6,10 +6,10 @@ module Heist.Common where
 
 ------------------------------------------------------------------------------
 import           Control.Applicative      (Alternative (..), Applicative (..), (<$>))
-import           Control.Error
 import           Control.Exception        (SomeException)
 import qualified Control.Exception.Lifted as C
 import           Control.Monad            (liftM, mplus)
+import           Control.Monad.Trans.Either
 import qualified Data.Attoparsec.Text     as AP
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString          as B
@@ -19,6 +19,7 @@ import           Data.HashMap.Strict      (HashMap)
 import qualified Data.HashMap.Strict      as Map
 import           Data.List                (isSuffixOf)
 import           Data.Map.Syntax
+import           Data.Maybe               (isJust)
 import           Data.Monoid              (Monoid (..), (<>))
 import           Data.Text                (Text)
 import qualified Data.Text                as T

--- a/src/Heist/Internal/Types.hs
+++ b/src/Heist/Internal/Types.hs
@@ -22,7 +22,7 @@ module Heist.Internal.Types
 
 ------------------------------------------------------------------------------
 import           Control.Applicative
-import           Control.Error
+import           Control.Monad.Trans.Either
 import           Data.HashMap.Strict (HashMap)
 import           Data.Monoid
 import           Data.Text (Text)

--- a/src/Heist/TemplateDirectory.hs
+++ b/src/Heist/TemplateDirectory.hs
@@ -17,9 +17,9 @@ module Heist.TemplateDirectory
 
 ------------------------------------------------------------------------------
 import           Control.Concurrent
-import           Control.Error
 import           Control.Monad
 import           Control.Monad.Trans
+import           Control.Monad.Trans.Either
 import           Heist
 import           Heist.Internal.Types
 import           Heist.Splices.Cache


### PR DESCRIPTION
Compare and contrast with #66.

Given that `errors <= 2.0` depends on `either`, all that I've done with this change is remove the dependency on `errors`. Everything used in the Heist source was available via `Control.Monad.Trans.Either`, `Data.Either`, and `Data.Maybe`.

The lower bound on `either` could probably be relaxed significantly. I've only tried building it against lts-2.17 (either-4.3.4.1) and nightly-2015-07-07 (either-4.4.1), so the bounds I put are `>= 4.3 && < 4.5`.