### PR TITLE
Fix parse error for heist-testsuite.cabal

### DIFF
--- a/test/heist-testsuite.cabal
+++ b/test/heist-testsuite.cabal
@@ -39,7 +39,7 @@ Executable testsuite
     transformers-base,
     unordered-containers,
     vector,
-    xmlhtml,
+    xmlhtml
 
 
   ghc-options: -O2 -Wall -fhpc -fwarn-tabs -funbox-strict-fields -threaded
@@ -82,7 +82,7 @@ Executable benchmark
     transformers-base,
     unordered-containers,
     vector,
-    xmlhtml,
+    xmlhtml
 
   ghc-options: -O2 -Wall -fwarn-tabs -funbox-strict-fields -threaded
                -fno-warn-unused-do-bind -rtsopts


### PR DESCRIPTION
Reported in https://github.com/commercialhaskell/stack/issues/1011.