### PR TITLE
Loosen aeson deps to allow aeson 0.10

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -138,7 +138,7 @@ Library
     Heist.Interpreted.Internal
 
   build-depends:
-    aeson                      >= 0.6     && < 0.10,
+    aeson                      >= 0.6     && < 0.11,
     attoparsec                 >= 0.10    && < 0.14,
     base                       >= 4       && < 5,
     blaze-builder              >= 0.2     && < 0.5,


### PR DESCRIPTION
I couldn't get the test suite to build on my machine in either case. Travis certainly isn't running it, FYI. But I've verified the project builds on 0.10.0.0 and the release notes claim to be forward compatible.