### PR TITLE
Add namespace to bound splices and retain splice errors on restoreHS.

### DIFF
--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -50,6 +50,15 @@ runMapNoErrors :: (Eq k, Hashable k) => MapSyntaxM k v a -> HashMap k v
 runMapNoErrors = either (const mempty) id .
     runMapSyntax' (\_ new _ -> Just new) Map.lookup Map.insert
 
+applySpliceMap :: HeistState n
+                -> (HeistState n -> HashMap Text v)
+                -> MapSyntaxM Text v a
+                -> HashMap Text v
+applySpliceMap hs f =  (flip Map.union (f hs)) .
+    runMapNoErrors .
+    mapK (mappend pre)
+  where
+    pre = _splicePrefix hs
 
 ------------------------------------------------------------------------------
 -- | If Heist is running in fail fast mode, then this function will throw an
@@ -341,9 +350,7 @@ bindAttributeSplices :: Splices (AttrSplice n) -- ^ splices to bind
                      -> HeistState n           -- ^ start state
                      -> HeistState n
 bindAttributeSplices ss hs =
-    hs { _attrSpliceMap = Map.union (runMapNoErrors ss)
-                                    (_attrSpliceMap hs) }
-
+    hs { _attrSpliceMap = applySpliceMap hs _attrSpliceMap ss }
 
 ------------------------------------------------------------------------------
 -- | Mappends a doctype to the state.

--- a/src/Heist/Compiled/Internal.hs
+++ b/src/Heist/Compiled/Internal.hs
@@ -532,8 +532,9 @@ bindSplice :: Text             -- ^ tag name
            -> HeistState n     -- ^ source state
            -> HeistState n
 bindSplice n v ts =
-    ts { _compiledSpliceMap = H.insert n v (_compiledSpliceMap ts) }
-
+    ts { _compiledSpliceMap = H.insert n' v (_compiledSpliceMap ts) }
+  where
+    n' = _splicePrefix ts `mappend` n
 
 ------------------------------------------------------------------------------
 -- | Binds a list of compiled splices.  This function should not be exported.
@@ -541,8 +542,7 @@ bindSplices :: Splices (Splice n)  -- ^ splices to bind
             -> HeistState n        -- ^ source state
             -> HeistState n
 bindSplices ss hs =
-    hs { _compiledSpliceMap = H.union (runMapNoErrors ss)
-                                      (_compiledSpliceMap hs) }
+    hs { _compiledSpliceMap = applySpliceMap hs _compiledSpliceMap ss }
 
 
 ------------------------------------------------------------------------------

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -544,12 +544,14 @@ modifyHS f = HeistT $ \_ s -> return ((), f s)
 
 ------------------------------------------------------------------------------
 -- | Restores the HeistState.  This function is almost like putHS except it
--- preserves the current doctypes.  You should use this function instead of
--- @putHS@ to restore an old state.  This was needed because doctypes needs to
--- be in a "global scope" as opposed to the template call "local scope" of
--- state items such as recursionDepth, curContext, and spliceMap.
+-- preserves the current doctypes and splice errors.  You should use this
+-- function instead of @putHS@ to restore an old state.  This was needed
+-- because doctypes needs to be in a "global scope" as opposed to the template
+-- call "local scope" of state items such as recursionDepth, curContext, and
+-- spliceMap.
 restoreHS :: Monad m => HeistState n -> HeistT n m ()
-restoreHS old = modifyHS (\cur -> old { _doctypes = _doctypes cur })
+restoreHS old = modifyHS (\cur -> old { _doctypes = _doctypes cur
+                                      , _spliceErrors = _spliceErrors cur })
 {-# INLINE restoreHS #-}
 
 

--- a/src/Heist/Interpreted/Internal.hs
+++ b/src/Heist/Interpreted/Internal.hs
@@ -47,7 +47,7 @@ bindSplices :: Splices (Splice n) -- ^ splices to bind
             -> HeistState n       -- ^ start state
             -> HeistState n
 bindSplices ss hs =
-    hs { _spliceMap = Map.union (runMapNoErrors ss) (_spliceMap hs) }
+    hs { _spliceMap = applySpliceMap hs _spliceMap ss }
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Changes to bindSplice and bindSplices to make them preserve namespace prefix and to restoreHS to introduce splice errors to top level state.

I'm not sure how idiomatic "applySpliceMap" is as a name for my function. Feel free to change it.

I'm afraid I didn't quite retain the empty line usage in my patch.  Adjust as needed or ask me to resubmit.