### PR TITLE
More verbose template splice error messages with node trace.

### DIFF
--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -40,6 +40,7 @@ module Heist
   , RuntimeSplice
   , Chunk
   , HeistState
+  , SpliceError(..)
   , HeistT
 
   -- * Lenses (can be used with lens or lens-family)
@@ -77,6 +78,7 @@ module Heist
   , getDoc
   , getXMLDoc
   , tellSpliceError
+  , spliceErrorText
   , orError
   , Splices
   ) where
@@ -204,7 +206,7 @@ addTemplatePathPrefix dir ts
 -- | Creates an empty HeistState.
 emptyHS :: HE.KeyGen -> HeistState m
 emptyHS kg = HeistState Map.empty Map.empty Map.empty Map.empty Map.empty
-                        True [] 0 [] Nothing kg False Html "" [] False 0
+                        True [] [] 0 [] Nothing kg False Html "" [] False 0
 
 
 ------------------------------------------------------------------------------
@@ -340,4 +342,3 @@ initHeistWithCacheTag (HeistConfig sc ns enn) = do
             let hc = HeistConfig (mappend sc sc') ns enn
             hs <- initHeist' keyGen hc rawWithCache
             return $ fmap (,cts) hs
-

--- a/src/Heist/Compiled/Internal.hs
+++ b/src/Heist/Compiled/Internal.hs
@@ -170,12 +170,20 @@ compileTemplates
 compileTemplates hs = do
     (tmap, hs') <- runHeistT compileTemplates' (X.TextNode "") hs
     let pre = _splicePrefix hs'
+    let canError = _errorNotBound hs'
+    let errs = _spliceErrors hs'
     let nsErr = if not (T.null pre) && (_numNamespacedTags hs' == 0)
                   then Left [noNamespaceSplicesMsg $ T.unpack pre]
                   else Right ()
-    return $ case _spliceErrors hs' of
-               [] -> nsErr >> (Right $! hs { _compiledTemplateMap = tmap })
-               es -> Left $ either (++) (const id) nsErr $ map T.unpack es
+    return $ if canError
+               then case errs of
+                     [] -> nsErr >>
+                           (Right $! hs { _compiledTemplateMap = tmap })
+                     es -> Left $ either (++) (const id) nsErr $
+                           map (T.unpack . spliceErrorText) es
+               else nsErr >> (Right $! hs { _compiledTemplateMap = tmap
+                                          , _spliceErrors = errs
+                                          })
 
 
 ------------------------------------------------------------------------------
@@ -263,11 +271,9 @@ lookupSplice :: Text -> HeistT n IO (Maybe (Splice n))
 lookupSplice nm = do
     pre <- getsHS _splicePrefix
     res <- getsHS (H.lookup nm . _compiledSpliceMap)
-    canError <- getsHS _errorNotBound
     if isNothing res && T.isPrefixOf pre nm && not (T.null pre)
       then do
-          when canError $
-            tellSpliceError $ "No splice bound for " `mappend` nm
+          tellSpliceError $ "No splice bound for " `mappend` nm
           return Nothing
       else return res
 
@@ -278,14 +284,18 @@ lookupSplice nm = do
 -- compileNode to generate the appropriate runtime computation.
 runNode :: Monad n => X.Node -> Splice n
 runNode node = localParamNode (const node) $ do
-    pre <- getsHS _splicePrefix
+    hs <- getHS
+    let pre = _splicePrefix hs
     let hasPrefix = (T.isPrefixOf pre `fmap` X.tagName node) == Just True
     when (not (T.null pre) && hasPrefix) incNamespacedTags
     isStatic <- subtreeIsStatic node
     markup <- getsHS _curMarkup
     if isStatic
       then return $! yieldPure $! renderFragment markup [parseAttrs node]
-      else compileNode node
+      else localHS (\hs' -> hs' {_splicePath =
+                                 (_curContext hs', _curTemplateFile hs',
+                                  X.elementTag node):(_splicePath hs')}) $
+           compileNode node
 
 
 parseAttrs :: X.Node -> X.Node

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -166,6 +166,16 @@ type AttrSplice m = Text -> RuntimeSplice m [(Text, Text)]
 
 
 ------------------------------------------------------------------------------
+-- | Detailed information about a splice error.
+data SpliceError = SpliceError
+    { spliceHistory      :: [(TPath, Maybe FilePath, Text)]
+    , spliceTemplateFile :: Maybe FilePath
+    , visibleSplices     :: [Text]
+    , spliceMsg          :: Text
+    } deriving ( Show, Eq )
+
+
+------------------------------------------------------------------------------
 -- | Holds all the state information needed for template processing.  You will
 -- build a @HeistState@ using 'initHeist' and any of Heist's @HeistState ->
 -- HeistState@ \"filter\" functions.  Then you use the resulting @HeistState@
@@ -190,6 +200,8 @@ data HeistState m = HeistState {
     , _recurse             :: Bool
     -- | The path to the template currently being processed.
     , _curContext          :: TPath
+    -- | Stack of the splices used.
+    , _splicePath          :: [(TPath, Maybe FilePath, Text)]
     -- | A counter keeping track of the current recursion depth to prevent
     -- infinite loops.
     , _recursionDepth      :: Int
@@ -213,7 +225,7 @@ data HeistState m = HeistState {
     , _splicePrefix        :: Text
 
     -- | List of errors encountered during splice processing.
-    , _spliceErrors        :: [Text]
+    , _spliceErrors        :: [SpliceError]
 
     -- | Whether to throw an error when a tag wih the heist namespace does not
     -- correspond to a bound splice.  When not using a namespace, this flag is

--- a/test/templates-nsbind/nsbinderror.tpl
+++ b/test/templates-nsbind/nsbinderror.tpl
@@ -1,4 +1,10 @@
 Alpha
+<h:invalid1/>
 <h:main>
-<h:invalid/>
+<h:recurse>
+<h:invalid2/>
+</h:recurse>
 </h:main>
+<h:main2>
+<h:invalid3/>
+</h:main2>


### PR DESCRIPTION
This patch adds more context to splice error messages and exposes the context as data and not just as a `String`.

This changes the semantics of `_errorNotBound` somewhat. Instead of filtering all splice error messages from `_spliceErrors` this patch always adds them to it. What `_errorNotBound` does instead is to control whether they are turned into a `Left`.