### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -144,7 +144,7 @@ Library
     containers                 >= 0.2     && < 0.6,
     directory                  >= 1.1     && < 1.3,
     directory-tree             >= 0.10    && < 0.13,
-    dlist                      >= 0.5     && < 0.8,
+    dlist                      >= 0.5     && < 0.9,
     filepath                   >= 1.3     && < 1.5,
     hashable                   >= 1.1     && < 1.3,
     lifted-base                >= 0.2     && < 0.3,


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `heist`, but I don't think it will be break anything.