### PR TITLE
Bump aeson, QuickCheck, and bifunctors to latest versions.

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -135,7 +135,7 @@ Library
     Heist.Interpreted.Internal
 
   build-depends:
-    aeson                      >= 0.6     && < 0.12,
+    aeson                      >= 0.6     && < 1.1,
     attoparsec                 >= 0.10    && < 0.14,
     base                       >= 4       && < 5,
     blaze-builder              >= 0.2     && < 0.5,
@@ -191,7 +191,7 @@ Test-suite testsuite
 
   build-depends:
     HUnit                      >= 1.2      && < 2,
-    QuickCheck                 >= 2        && < 2.9,
+    QuickCheck                 >= 2        && < 2.10,
     lens                       >= 4.3      && < 4.15,
     test-framework             >= 0.4      && < 0.9,
     test-framework-hunit       >= 0.2.7    && < 0.4,
@@ -199,7 +199,7 @@ Test-suite testsuite
     aeson,
     attoparsec,
     base,
-    bifunctors >= 5.3 && < 5.4,
+    bifunctors >= 5.3 && < 5.5,
     blaze-builder,
     blaze-html,
     bytestring,


### PR DESCRIPTION
I couldn't run all the tests since I don't have the pandoc executable, so let's see what travis says.
