### PR TITLE
Exceptions stacktrace

### DIFF
--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -41,6 +41,7 @@ module Heist
   , Chunk
   , HeistState
   , SpliceError(..)
+  , CompileException(..)
   , HeistT
 
   -- * Lenses (can be used with lens or lens-family)

--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -103,23 +103,6 @@ tellSpliceError msg = do
 
 
 ------------------------------------------------------------------------------
--- | Transform a SpliceError record to a Text message.
-spliceErrorText :: SpliceError -> Text
-spliceErrorText (SpliceError hist tf splices node msg) =
-    (maybe "" ((`mappend` ": ") . T.pack) tf) `T.append` msg `T.append`
-    foldr (\(_, tf', tag) -> (("\n   ... via " `T.append`
-                               (maybe "" ((`mappend` ": ") . T.pack) tf')
-                               `T.append` tag) `T.append`)) T.empty hist
-    `T.append`
-    if null splices
-      then T.empty
-      else "\nBound splices:" `T.append`
-         foldl (\x y -> x `T.append` " " `T.append` y) T.empty splices
-    `T.append`
-    (T.pack $ "\nNode: " ++ (show node))
-
-
-------------------------------------------------------------------------------
 -- | Function for showing a TPath.
 showTPath :: TPath -> String
 showTPath = BC.unpack . (`BC.append` ".tpl") . tpathName

--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -91,10 +91,12 @@ heistErrMsg msg = do
 tellSpliceError :: Monad m => Text -> HeistT n m ()
 tellSpliceError msg = do
     hs <- getHS
+    node <- getParamNode
     let spliceError = SpliceError
                       { spliceHistory = _splicePath hs
                       , spliceTemplateFile = _curTemplateFile hs
                       , visibleSplices = Map.keys $ _compiledSpliceMap hs
+                      , contextNode = node
                       , spliceMsg = msg
                       }
     modifyHS (\hs' -> hs { _spliceErrors = spliceError : _spliceErrors hs' })
@@ -103,7 +105,7 @@ tellSpliceError msg = do
 ------------------------------------------------------------------------------
 -- | Transform a SpliceError record to a Text message.
 spliceErrorText :: SpliceError -> Text
-spliceErrorText (SpliceError hist tf splices msg) =
+spliceErrorText (SpliceError hist tf splices node msg) =
     (maybe "" ((`mappend` ": ") . T.pack) tf) `T.append` msg `T.append`
     foldr (\(_, tf', tag) -> (("\n   ... via " `T.append`
                                (maybe "" ((`mappend` ": ") . T.pack) tf')
@@ -113,6 +115,8 @@ spliceErrorText (SpliceError hist tf splices msg) =
       then T.empty
       else "\nBound splices:" `T.append`
          foldl (\x y -> x `T.append` " " `T.append` y) T.empty splices
+    `T.append`
+    (T.pack $ "\nNode: " ++ (show node))
 
 
 ------------------------------------------------------------------------------

--- a/src/Heist/Compiled/Internal.hs
+++ b/src/Heist/Compiled/Internal.hs
@@ -606,13 +606,14 @@ renderTemplate hs nm =
 -- | Looks up a compiled template and returns a compiled splice.
 callTemplate :: Monad n
              => ByteString
-             -> HeistT n IO (DList (Chunk n))
+             -> Splice n
 callTemplate nm = do
     hs <- getHS
-    runNodeList $ maybe (error err) (X.docContent . dfDoc . fst) $
-      lookupTemplate nm hs _templateMap
+    maybe (error err) call $ lookupTemplate nm hs _templateMap
   where
     err = "callTemplate: "++(T.unpack $ T.decodeUtf8 nm)++(" does not exist")
+    call (df,_) = localHS (\hs' -> hs' {_curTemplateFile = dfFile df}) $
+                    runNodeList $ X.docContent $ dfDoc df
 
 
 interpret :: Monad n => DList (Chunk n) -> n Builder

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -204,7 +204,7 @@ data CompileException = forall e . Exception e => CompileException
     -- The list of splice errors.  The head of it has the context
     -- related to the exception.
     , exceptionContext :: [SpliceError]
-#if !MIN_VERSION_base(4,7,0)
+#if MIN_VERSION_base(4,7,0)
 } deriving ( Typeable )
 #else
 }

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -204,7 +204,11 @@ data CompileException = forall e . Exception e => CompileException
     -- The list of splice errors.  The head of it has the context
     -- related to the exception.
     , exceptionContext :: [SpliceError]
-    }
+#if !MIN_VERSION_base(4,7,0)
+} deriving ( Typeable )
+#else
+}
+#endif
 
 
 instance Show CompileException where

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -204,11 +204,7 @@ data CompileException = forall e . Exception e => CompileException
     -- The list of splice errors.  The head of it has the context
     -- related to the exception.
     , exceptionContext :: [SpliceError]
-#if MIN_VERSION_base(4,7,0)
-} deriving ( Typeable )
-#else
-}
-#endif
+    } deriving ( Typeable )
 
 
 instance Show CompileException where

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -171,6 +171,7 @@ data SpliceError = SpliceError
     { spliceHistory      :: [(TPath, Maybe FilePath, Text)]
     , spliceTemplateFile :: Maybe FilePath
     , visibleSplices     :: [Text]
+    , contextNode        :: X.Node
     , spliceMsg          :: Text
     } deriving ( Show, Eq )
 

--- a/src/Heist/Internal/Types/HeistState.hs
+++ b/src/Heist/Internal/Types/HeistState.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -23,6 +24,7 @@ module Heist.Internal.Types.HeistState where
 import           Blaze.ByteString.Builder      (Builder)
 import           Control.Applicative           (Alternative (..))
 import           Control.Arrow                 (first)
+import           Control.Exception             (Exception)
 import           Control.Monad                 (MonadPlus (..), ap)
 import           Control.Monad.Base
 import           Control.Monad.Cont            (MonadCont (..))
@@ -174,6 +176,44 @@ data SpliceError = SpliceError
     , contextNode        :: X.Node
     , spliceMsg          :: Text
     } deriving ( Show, Eq )
+
+
+------------------------------------------------------------------------------
+-- | Transform a SpliceError record to a Text message.
+spliceErrorText :: SpliceError -> Text
+spliceErrorText (SpliceError hist tf splices node msg) =
+    (maybe "" ((`mappend` ": ") . T.pack) tf) `T.append` msg `T.append`
+    foldr (\(_, tf', tag) -> (("\n   ... via " `T.append`
+                               (maybe "" ((`mappend` ": ") . T.pack) tf')
+                               `T.append` tag) `T.append`)) T.empty hist
+    `T.append`
+    if null splices
+      then T.empty
+      else "\nBound splices:" `T.append`
+         foldl (\x y -> x `T.append` " " `T.append` y) T.empty splices
+    `T.append`
+    (T.pack $ "\nNode: " ++ (show node))
+
+
+------------------------------------------------------------------------------
+-- | Exception type for splice compile errors.  Wraps the original
+-- exception and provides context.
+--data (Exception e) => CompileException e = CompileException
+data CompileException = forall e . Exception e => CompileException
+    { originalException :: e
+    -- The list of splice errors.  The head of it has the context
+    -- related to the exception.
+    , exceptionContext :: [SpliceError]
+    }
+
+
+instance Show CompileException where
+    show (CompileException e []) =
+      "Heist load exception (unknown context): " ++ (show e)
+    show (CompileException _ (c:_)) = (T.unpack $ spliceErrorText c)
+
+
+instance Exception CompileException
 
 
 ------------------------------------------------------------------------------

--- a/test/suite/Heist/Compiled/Tests.hs
+++ b/test/suite/Heist/Compiled/Tests.hs
@@ -17,6 +17,7 @@ import           Data.Text.Encoding
 import           Test.Framework (Test)
 import           Test.Framework.Providers.HUnit
 import qualified Test.HUnit as H
+import qualified Text.XmlHtml as X
 
 
 ------------------------------------------------------------------------------
@@ -237,9 +238,9 @@ nsBindErrorTest = do
 
     H.assertEqual "namespace bind error test" (Left [ err1, err2, err3 ])  res
   where
-    err1 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid3\n   ... via templates-nsbind/nsbinderror.tpl: h:main2\nBound splices: h:sub h:recurse h:call h:main2 h:main"
-    err2 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid2\n   ... via templates-nsbind/nsbinderror.tpl: h:recurse\n   ... via templates-nsbind/nsbinderror.tpl: h:main\nBound splices: h:sub h:recurse h:call h:main2 h:main"
-    err3 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid1\nBound splices: h:call h:main2 h:main"
+    err1 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid3\n   ... via templates-nsbind/nsbinderror.tpl: h:main2\nBound splices: h:sub h:recurse h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid3\", elementAttrs = [], elementChildren = []}"
+    err2 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid2\n   ... via templates-nsbind/nsbinderror.tpl: h:recurse\n   ... via templates-nsbind/nsbinderror.tpl: h:main\nBound splices: h:sub h:recurse h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid2\", elementAttrs = [], elementChildren = []}"
+    err3 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid1\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid1\", elementAttrs = [], elementChildren = []}"
 
 
 ------------------------------------------------------------------------------
@@ -256,6 +257,7 @@ nsBindStackTest = do
                          , "h:main2") ]
                (Just "templates-nsbind/nsbinderror.tpl")
                ["h:sub","h:recurse","h:call","h:main2","h:main"]
+               (X.Element "h:invalid3" [] [])
                "No splice bound for h:invalid3"
     err2 = SpliceError [ ( ["nsbinderror"]
                          , Just "templates-nsbind/nsbinderror.tpl"
@@ -265,10 +267,12 @@ nsBindStackTest = do
                          ,"h:main") ]
                (Just "templates-nsbind/nsbinderror.tpl")
                ["h:sub","h:recurse","h:call","h:main2","h:main"]
+               (X.Element "h:invalid2" [] [])
                "No splice bound for h:invalid2"
     err3 = SpliceError []
                (Just "templates-nsbind/nsbinderror.tpl")
                ["h:call","h:main2","h:main"]
+               (X.Element "h:invalid1" [] [])
                "No splice bound for h:invalid1"
 
 
@@ -302,5 +306,5 @@ nsCallErrTest = do
       (Left $ Set.fromList [ err1, err2 ])
       (first Set.fromList res)
   where
-    err1 = "templates-nscall/_call.tpl: No splice bound for h:sub\nBound splices: h:call h:main2 h:main"
-    err2 = "templates-nscall/_invalid.tpl: No splice bound for h:invalid\nBound splices: h:call h:main2 h:main"
+    err1 = "templates-nscall/_call.tpl: No splice bound for h:sub\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:sub\", elementAttrs = [], elementChildren = []}"
+    err2 = "templates-nscall/_invalid.tpl: No splice bound for h:invalid\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid\", elementAttrs = [], elementChildren = []}"

--- a/test/suite/Heist/Compiled/Tests.hs
+++ b/test/suite/Heist/Compiled/Tests.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Heist.Compiled.Tests where
 
 import           Blaze.ByteString.Builder
+import           Control.Exception
 import           Control.Monad.Trans.Except
 import           Control.Lens
 import           Control.Monad.Trans
@@ -10,9 +12,11 @@ import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import           Data.Char
+import           Data.Maybe
 import           Data.Map.Syntax
 import           Data.Monoid
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import           Data.Text.Encoding
 import           Test.Framework (Test)
 import           Test.Framework.Providers.HUnit
@@ -48,6 +52,7 @@ tests = [ testCase     "compiled/simple"        simpleCompiledTest
         , testCase     "compiled/nscallerr"     nsCallErrTest
         , testCase     "compiled/nsbindstack"   nsBindStackTest
         , testCase     "compiled/doctype"       doctypeTest
+        , testCase     "compiled/exceptions"    exceptionsTest
         ]
 
 simpleCompiledTest :: IO ()
@@ -308,3 +313,45 @@ nsCallErrTest = do
   where
     err1 = "templates-nscall/_call.tpl: No splice bound for h:sub\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:sub\", elementAttrs = [], elementChildren = []}"
     err2 = "templates-nscall/_invalid.tpl: No splice bound for h:invalid\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid\", elementAttrs = [], elementChildren = []}"
+
+
+------------------------------------------------------------------------------
+-- | Test exception handling in template load.
+exceptionsTest :: IO ()
+exceptionsTest = do
+    res <- catch (runExceptT $ do
+                      hs <- ExceptT $ initHeist hc
+                      -- The rest needed only for type inference.
+                      runner <- noteT ["Error rendering"] $ hoistMaybe $
+                                  renderTemplate hs ""
+                      _ <- lift $ fst runner
+                      throwE ["Unexpected success"])
+             (\(e :: CompileException) -> return $ Right
+                                            (show e, head $
+                                                       exceptionContext e))
+
+    H.assertEqual "exceptions" (Right (msg, err)) $ res
+
+  where
+    msg = "templates-loaderror/_error.tpl: Exception in splice compile: Prelude.read: no parse\n   ... via templates-loaderror/_error.tpl: h:adder\n   ... via templates-loaderror/test.tpl: h:call2\nBound splices: h:adder h:call2 h:call1\nNode: Element {elementTag = \"h:adder\", elementAttrs = [(\"value\",\"noparse\")], elementChildren = []}"
+    err = SpliceError [ ( ["test"]
+                        , Just "templates-loaderror/_error.tpl"
+                        , "h:adder"),
+                        ( ["test"]
+                        , Just "templates-loaderror/test.tpl"
+                        ,"h:call2") ]
+              (Just "templates-loaderror/_error.tpl")
+              ["h:adder", "h:call2", "h:call1"]
+              (X.Element "h:adder" [("value", "noparse")] [])
+              "Exception in splice compile: Prelude.read: no parse"
+    hc = HeistConfig sc "h" True
+    sc = mempty & scLoadTimeSplices .~ defaultLoadTimeSplices
+                & scCompiledSplices .~ splices
+                & scTemplateLocations .~ [loadTemplates "templates-loaderror"]
+    splices = do
+        "call1" ## callTemplate "_ok"
+        "call2" ## callTemplate "_error"
+        "adder" ## do
+            value :: Int <- read . T.unpack . fromJust .
+                              X.getAttribute "value" <$> getParamNode
+            return $ yieldPureText $ T.pack $ show $ 1 + value

--- a/test/suite/Heist/Compiled/Tests.hs
+++ b/test/suite/Heist/Compiled/Tests.hs
@@ -4,6 +4,7 @@
 module Heist.Compiled.Tests where
 
 import           Blaze.ByteString.Builder
+import           Control.Applicative
 import           Control.Exception
 import           Control.Monad.Trans.Except
 import           Control.Lens

--- a/test/suite/Heist/Compiled/Tests.hs
+++ b/test/suite/Heist/Compiled/Tests.hs
@@ -320,13 +320,14 @@ nsCallErrTest = do
 -- | Test exception handling in template load.
 exceptionsTest :: IO ()
 exceptionsTest = do
-    res <- catch (runExceptT $ do
-                      hs <- ExceptT $ initHeist hc
-                      -- The rest needed only for type inference.
-                      runner <- noteT ["Error rendering"] $ hoistMaybe $
-                                  renderTemplate hs ""
-                      _ <- lift $ fst runner
-                      throwE ["Unexpected success"])
+    res <- Control.Exception.catch
+             (runExceptT $ do
+                  hs <- ExceptT $ initHeist hc
+                  -- The rest needed only for type inference.
+                  runner <- noteT ["Error rendering"] $ hoistMaybe $
+                              renderTemplate hs ""
+                  _ <- lift $ fst runner
+                  throwE ["Unexpected success"])
              (\(e :: CompileException) -> return $ Right
                                             (show e, head $
                                                        exceptionContext e))


### PR DESCRIPTION
This code adds exception handling to template loading. I'm afraid runNode got uglier by this change, I had to make sure that the consolidate evaluation happens already there. By the time the consolidate in compileTemplate would get run the context would already have been lost. I'm not sure whether this causes the pure bytestrings to be created twice.

callTemplate didn't seem right with its lacking _curTemplateFile manipulation and I added it as another patch in this branch.