### PR TITLE
Remove unneeded line from failingSplice.

### DIFF
--- a/src/Heist/Compiled/Internal.hs
+++ b/src/Heist/Compiled/Internal.hs
@@ -255,7 +255,7 @@ consolidate = consolidateL . DL.toList
 
 
 ------------------------------------------------------------------------------
--- | Given a list of output chunks, consolidate turns consecutive runs of
+-- | Given a list of output chunks, codeGen turns consecutive runs of
 -- @Pure Html@ values into maximally-efficient pre-rendered strict
 -- 'ByteString' chunks.
 codeGen :: Monad n => DList (Chunk n) -> RuntimeSplice n Builder
@@ -758,7 +758,7 @@ deferMany f getItems = do
 
 
 ------------------------------------------------------------------------------
--- | Saves the results of a runtme computation in a 'Promise' so they don't
+-- | Saves the results of a runtime computation in a 'Promise' so they don't
 -- get recalculated if used more than once.
 --
 -- Note that this is just a specialized version of function application ($)

--- a/test/suite/Heist/Tutorial/CompiledSplices.lhs
+++ b/test/suite/Heist/Tutorial/CompiledSplices.lhs
@@ -249,7 +249,6 @@ differently in the case of failure.
 
 < failingSplice :: MonadSnap m => C.Splice m
 < failingSplice = do
-<     children <- childNodes <$> getParamNode
 <     promise <- C.newEmptyPromise
 <     outputChildren <- C.withSplices C.runChildren splices (C.getPromise promise)
 <     return $ C.yieldRuntime $ do         


### PR DESCRIPTION
The first line of `failingSplice` had me confused for a while.  `children` isn't used anywhere, and the call has no apparent side effects.  I'm now convinced it shouldn't be there at all and was probably copied from some other code snippet.

Two other minor corrections.