### PR TITLE
Fix build on GHC-{7.4.2, 7.6.3, 7.8.4}

### DIFF
--- a/src/Heist/Interpreted/Internal.hs
+++ b/src/Heist/Interpreted/Internal.hs
@@ -7,7 +7,6 @@ module Heist.Interpreted.Internal where
 
 ------------------------------------------------------------------------------
 import           Blaze.ByteString.Builder
-import           Control.Arrow                 ((&&&))
 import           Control.Monad
 import           Control.Monad.State.Strict
 import qualified Data.Attoparsec.Text          as AP
@@ -397,9 +396,10 @@ renderTemplate :: Monad n
                -> ByteString
                -> n (Maybe (Builder, MIMEType))
 renderTemplate hs name = evalHeistT tpl (X.TextNode "") hs
-  where tpl = (fmap .fmap)
-              (X.render &&& mimeType)
-              (evalWithDoctypes name)
+  where tpl = do mt <- evalWithDoctypes name
+                 case mt of
+                    Nothing  -> return Nothing
+                    Just doc -> return $ Just $ (X.render doc, mimeType doc)
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Revert part of 65961a7 to support pre-AMP versions of GHC.