### PR TITLE
When testing, mock out pandoc 1.* if it is unavailable

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -236,6 +236,7 @@ Test-suite testsuite
     time,
     transformers,
     transformers-base,
+    unix,
     unordered-containers,
     vector,
     xmlhtml

--- a/test/pandoc
+++ b/test/pandoc
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Mock implementation of pandoc.
+
+echo '<p>This <em>is</em> a test.</p>'
+

--- a/test/suite/TestSuite.hs
+++ b/test/suite/TestSuite.hs
@@ -1,16 +1,24 @@
 module Main where
 
-import System.Directory
-import Test.Framework (defaultMain, testGroup)
+import           Control.Monad           (liftM, when)
+import           Data.List               (isPrefixOf)
+import           System.Directory        (findExecutable, setCurrentDirectory)
+import           System.Environment      (setEnv)
+import           System.Process          (readProcess)
+import           Test.Framework          (defaultMain, testGroup)
 
-import qualified Heist.Interpreted.Tests
 import qualified Heist.Compiled.Tests
+import qualified Heist.Interpreted.Tests
 import qualified Heist.Tests
 
 main :: IO ()
 main = do
     -- Need to change directory after we switched to cabal test infra
     setCurrentDirectory "test"
+    shouldMockPandoc <- pandoc1Unavailable
+    when shouldMockPandoc $ do
+        putStrLn "Using mock pandoc implementation."
+        setEnv "PATH" "."
     defaultMain tests
   where tests = [ testGroup "Heist.Interpreted.Tests"
                             Heist.Interpreted.Tests.tests
@@ -19,3 +27,11 @@ main = do
                 , testGroup "Heist.Tests"
                             Heist.Tests.tests
                 ]
+
+pandoc1Unavailable :: IO Bool
+pandoc1Unavailable =
+    maybe (return True) (liftM not1 . version) =<< findExecutable "pandoc"
+  where
+    version path = readProcess path ["--version"] ""
+    not1 = not . ("pandoc 1" `isPrefixOf`)
+

--- a/test/suite/TestSuite.hs
+++ b/test/suite/TestSuite.hs
@@ -3,7 +3,7 @@ module Main where
 import           Control.Monad           (liftM, when)
 import           Data.List               (isPrefixOf)
 import           System.Directory        (findExecutable, setCurrentDirectory)
-import           System.Environment      (setEnv)
+import           System.Posix.Env        (setEnv)
 import           System.Process          (readProcess)
 import           Test.Framework          (defaultMain, testGroup)
 
@@ -18,7 +18,7 @@ main = do
     shouldMockPandoc <- pandoc1Unavailable
     when shouldMockPandoc $ do
         putStrLn "Using mock pandoc implementation."
-        setEnv "PATH" "."
+        setEnv "PATH" "." True
     defaultMain tests
   where tests = [ testGroup "Heist.Interpreted.Tests"
                             Heist.Interpreted.Tests.tests


### PR DESCRIPTION
Fixes #98. Makes #111 obsolete.

It's pretty hacky, and obviously doesn't work on Windows.

However, mocking the markdown splice directly would require extensive surgery on the tests. They get their splices in various different ways (`default{LoadTime,Interpreted}Splices`, `markdownSplice`, `pandocSplice`). Testing the examples in the literate Haskell tutorial poses another problem.

I think deciding how to properly parameterise the tests could wait until the public API supports pandoc 2.\* -- a separate issue.
