### PR TITLE
Improve error message in preprocess

### DIFF
--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -314,7 +314,6 @@ preprocess (tpath, docFile) = do
               :: HeistT IO IO (Either SomeException (Maybe X.Document))
     let f !doc = (tpath, docFile { dfDoc = doc })
     return $! either (Left . show) (Right . maybe die f) emdoc
-  where
 
 
 ------------------------------------------------------------------------------

--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -91,6 +91,7 @@ module Heist
 import           Control.Exception.Lifted
 import           Control.Monad.State
 import           Data.ByteString               (ByteString)
+import qualified Data.ByteString.Char8         as BC
 import qualified Data.ByteString               as B
 import           Data.Either
 import qualified Data.Foldable                 as F
@@ -306,12 +307,14 @@ preprocess :: (TPath, DocumentFile)
            -> HeistT IO IO (Either String (TPath, DocumentFile))
 preprocess (tpath, docFile) = do
     let tname = tpathName tpath
+        die   = error $ "Preprocess failed because the template `"
+                     ++ BC.unpack tname
+                     ++ "` was not found in the template repository."
     !emdoc <- try $ I.evalWithDoctypes tname
               :: HeistT IO IO (Either SomeException (Maybe X.Document))
     let f !doc = (tpath, docFile { dfDoc = doc })
     return $! either (Left . show) (Right . maybe die f) emdoc
   where
-    die = error "Preprocess didn't succeed!  This should never happen."
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The current error message gives no information on what goes wrong if you try to render a template for which you've mistyped the name. This patch should make it easier for the user to track down what they did wrong.