### PR TITLE
Bump aeson upper bound

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -162,7 +162,7 @@ Library
     Heist.Interpreted.Internal
 
   build-depends:
-    aeson                      >= 0.6     && < 1.5,
+    aeson                      >= 0.6     && < 1.6,
     attoparsec                 >= 0.10    && < 0.14,
     base                       >= 4.5     && < 4.15,
     blaze-builder              >= 0.2     && < 0.5,


### PR DESCRIPTION
I have confirmed, that this compiles and passes tests with aeson 1.5.4.0