### PR TITLE
Bump aeson

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -162,7 +162,7 @@ Library
     Heist.Interpreted.Internal
 
   build-depends:
-    aeson                      >= 0.6     && < 1.6,
+    aeson                      >= 0.6     && < 3,
     attoparsec                 >= 0.10    && < 0.14,
     base                       >= 4.5     && < 4.15,
     blaze-builder              >= 0.2     && < 0.5,
@@ -186,7 +186,8 @@ Library
     transformers-base          >= 0.4     && < 0.5,
     unordered-containers       >= 0.1.4   && < 0.3,
     vector                     >= 0.9     && < 0.13,
-    xmlhtml                    >= 0.2.3.5 && < 0.3
+    xmlhtml                    >= 0.2.3.5 && < 0.3,
+    indexed-traversable
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.16 && < 0.19
@@ -251,7 +252,9 @@ Test-suite testsuite
     transformers-base,
     unordered-containers,
     vector,
-    xmlhtml
+    xmlhtml,
+    indexed-traversable
+
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.16 && < 0.19
@@ -301,7 +304,9 @@ Benchmark benchmark
     transformers-base,
     unordered-containers,
     vector,
-    xmlhtml
+    xmlhtml,
+    indexed-traversable
+
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.16 && < 0.19

--- a/heist.cabal
+++ b/heist.cabal
@@ -162,7 +162,7 @@ Library
     Heist.Interpreted.Internal
 
   build-depends:
-    aeson                      >= 0.6     && < 3,
+    aeson                      >= 0.6     && < 2.1,
     attoparsec                 >= 0.10    && < 0.14,
     base                       >= 4.5     && < 4.15,
     blaze-builder              >= 0.2     && < 0.5,

--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString.Char8    as BC
 import           Data.Hashable            (Hashable)
 import           Data.HashMap.Strict      (HashMap)
 import qualified Data.HashMap.Strict      as Map
-import           Data.List                (isSuffixOf)
+import           Data.List                (isSuffixOf, sort)
 import           Data.Map.Syntax
 import           Data.Maybe               (isJust)
 import           Data.Monoid              ((<>))

--- a/src/Heist/Common.hs
+++ b/src/Heist/Common.hs
@@ -95,7 +95,7 @@ tellSpliceError msg = do
     let spliceError = SpliceError
                       { spliceHistory = _splicePath hs
                       , spliceTemplateFile = _curTemplateFile hs
-                      , visibleSplices = Map.keys $ _compiledSpliceMap hs
+                      , visibleSplices = sort $ Map.keys $ _compiledSpliceMap hs
                       , contextNode = node
                       , spliceMsg = msg
                       }

--- a/src/Heist/Splices/Json.hs
+++ b/src/Heist/Splices/Json.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,7 +12,13 @@ import           Control.Monad.Reader
 import           Data.Aeson
 import qualified Data.ByteString.Char8       as S
 import qualified Data.ByteString.Lazy.Char8  as L
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap           as KM
+import qualified Data.Aeson.Key              as K
+import qualified Data.Foldable.WithIndex     as FI
+#else
 import qualified Data.HashMap.Strict         as Map
+#endif
 import           Data.Map.Syntax
 import           Data.Maybe
 import           Data.Text                   (Text)
@@ -89,7 +96,20 @@ boolToText b = if b then "true" else "false"
 numToText :: ToJSON a => a -> Text
 numToText = T.decodeUtf8 . S.concat . L.toChunks . encode
 
+#if MIN_VERSION_aeson(2,0,0)
+------------------------------------------------------------------------------
+findExpr :: Text -> Value -> Maybe Value
+findExpr t = go (T.split (=='.') t)
+  where
+    go [] !value     = Just value
+    go (x:xs) !value = findIn value >>= go xs
+      where
+        findIn (Object obj) = KM.lookup (K.fromText x) obj
+        findIn (Array arr)  = tryReadIndex >>= \i -> arr V.!? i
+        findIn _            = Nothing
 
+        tryReadIndex = fmap fst . listToMaybe . reads . T.unpack $ x
+#else
 ------------------------------------------------------------------------------
 findExpr :: Text -> Value -> Maybe Value
 findExpr t = go (T.split (=='.') t)
@@ -102,7 +122,7 @@ findExpr t = go (T.split (=='.') t)
         findIn _            = Nothing
 
         tryReadIndex = fmap fst . listToMaybe . reads . T.unpack $ x
-
+#endif
 
 ------------------------------------------------------------------------------
 asHtml :: Monad m => Text -> m [Node]
@@ -214,6 +234,22 @@ explodeTag = ask >>= go
         "value"    ## varAttrTag v valueTag
 
 
+#if MIN_VERSION_aeson(2,0,0)
+    --------------------------------------------------------------------------
+    goObject :: KM.KeyMap Value -> ReaderT Value (HeistT n n) Template
+    goObject obj = do
+        start <- genericBindings
+        let bindings = FI.ifoldl' bindKvp start  obj
+        lift $ runChildrenWith bindings
+
+    --------------------------------------------------------------------------
+    bindKvp k bindings v =
+        let newBindings = do
+                T.append "with:" (K.toText k)    ## withValue v explodeTag
+                T.append "snippet:" (K.toText k) ## withValue v snippetTag
+                T.append "value:" (K.toText k)   ## withValue v valueTag
+        in  bindings >> newBindings
+#else
     --------------------------------------------------------------------------
     goObject obj = do
         start <- genericBindings
@@ -227,3 +263,4 @@ explodeTag = ask >>= go
                 T.append "snippet:" k ## withValue v snippetTag
                 T.append "value:" k   ## withValue v valueTag
         in  bindings >> newBindings
+#endif

--- a/src/Heist/Splices/Json.hs
+++ b/src/Heist/Splices/Json.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Heist.Splices.Json (
   bindJson
@@ -15,10 +16,10 @@ import qualified Data.ByteString.Lazy.Char8  as L
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap           as KM
 import qualified Data.Aeson.Key              as K
-import qualified Data.Foldable.WithIndex     as FI
 #else
 import qualified Data.HashMap.Strict         as Map
 #endif
+import qualified Data.Foldable.WithIndex     as FI
 import           Data.Map.Syntax
 import           Data.Maybe
 import           Data.Text                   (Text)
@@ -96,33 +97,23 @@ boolToText b = if b then "true" else "false"
 numToText :: ToJSON a => a -> Text
 numToText = T.decodeUtf8 . S.concat . L.toChunks . encode
 
+------------------------------------------------------------------------------
+findExpr :: Text -> Value -> Maybe Value
+findExpr t = go (T.split (=='.') t)
+  where
+    go [] !value     = Just value
+    go (x:xs) !value = findIn value >>= go xs
+      where
 #if MIN_VERSION_aeson(2,0,0)
-------------------------------------------------------------------------------
-findExpr :: Text -> Value -> Maybe Value
-findExpr t = go (T.split (=='.') t)
-  where
-    go [] !value     = Just value
-    go (x:xs) !value = findIn value >>= go xs
-      where
         findIn (Object obj) = KM.lookup (K.fromText x) obj
-        findIn (Array arr)  = tryReadIndex >>= \i -> arr V.!? i
-        findIn _            = Nothing
-
-        tryReadIndex = fmap fst . listToMaybe . reads . T.unpack $ x
 #else
-------------------------------------------------------------------------------
-findExpr :: Text -> Value -> Maybe Value
-findExpr t = go (T.split (=='.') t)
-  where
-    go [] !value     = Just value
-    go (x:xs) !value = findIn value >>= go xs
-      where
         findIn (Object obj) = Map.lookup x obj
+#endif
         findIn (Array arr)  = tryReadIndex >>= \i -> arr V.!? i
         findIn _            = Nothing
 
         tryReadIndex = fmap fst . listToMaybe . reads . T.unpack $ x
-#endif
+
 
 ------------------------------------------------------------------------------
 asHtml :: Monad m => Text -> m [Node]
@@ -234,33 +225,22 @@ explodeTag = ask >>= go
         "value"    ## varAttrTag v valueTag
 
 
-#if MIN_VERSION_aeson(2,0,0)
     --------------------------------------------------------------------------
-    goObject :: KM.KeyMap Value -> ReaderT Value (HeistT n n) Template
     goObject obj = do
         start <- genericBindings
         let bindings = FI.ifoldl' bindKvp start  obj
         lift $ runChildrenWith bindings
 
     --------------------------------------------------------------------------
+    
     bindKvp k bindings v =
-        let newBindings = do
-                T.append "with:" (K.toText k)    ## withValue v explodeTag
-                T.append "snippet:" (K.toText k) ## withValue v snippetTag
-                T.append "value:" (K.toText k)   ## withValue v valueTag
-        in  bindings >> newBindings
+#if MIN_VERSION_aeson(2,0,0)
+        let k' = K.toText k
 #else
-    --------------------------------------------------------------------------
-    goObject obj = do
-        start <- genericBindings
-        let bindings = Map.foldlWithKey' bindKvp start obj
-        lift $ runChildrenWith bindings
-
-    --------------------------------------------------------------------------
-    bindKvp bindings k v =
-        let newBindings = do
-                T.append "with:" k    ## withValue v explodeTag
-                T.append "snippet:" k ## withValue v snippetTag
-                T.append "value:" k   ## withValue v valueTag
-        in  bindings >> newBindings
+        let k' = k
 #endif
+            newBindings = do
+                T.append "with:" k'    ## withValue v explodeTag
+                T.append "snippet:" k' ## withValue v snippetTag
+                T.append "value:" k'   ## withValue v valueTag
+        in  bindings >> newBindings

--- a/src/Heist/Splices/Json.hs
+++ b/src/Heist/Splices/Json.hs
@@ -16,10 +16,10 @@ import qualified Data.ByteString.Lazy.Char8  as L
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap           as KM
 import qualified Data.Aeson.Key              as K
+import qualified Data.Foldable.WithIndex     as FI
 #else
 import qualified Data.HashMap.Strict         as Map
 #endif
-import qualified Data.Foldable.WithIndex     as FI
 import           Data.Map.Syntax
 import           Data.Maybe
 import           Data.Text                   (Text)
@@ -228,12 +228,16 @@ explodeTag = ask >>= go
     --------------------------------------------------------------------------
     goObject obj = do
         start <- genericBindings
-        let bindings = FI.ifoldl' bindKvp start  obj
+#if MIN_VERSION_aeson(2,0,0)
+        let bindings = FI.ifoldl' (flip bindKvp) start  obj
+#else
+        let bindings = Map.foldlWithKey' bindKvp start obj
+#endif
         lift $ runChildrenWith bindings
 
     --------------------------------------------------------------------------
     
-    bindKvp k bindings v =
+    bindKvp bindings k v =
 #if MIN_VERSION_aeson(2,0,0)
         let k' = K.toText k
 #else
@@ -243,4 +247,4 @@ explodeTag = ask >>= go
                 T.append "with:" k'    ## withValue v explodeTag
                 T.append "snippet:" k' ## withValue v snippetTag
                 T.append "value:" k'   ## withValue v valueTag
-        in  bindings >> newBindings
+        in  bindings >> newBindings    

--- a/test/suite/Heist/Compiled/Tests.hs
+++ b/test/suite/Heist/Compiled/Tests.hs
@@ -266,9 +266,9 @@ nsBindErrorTest = do
 
     H.assertEqual "namespace bind error test" (Left [ err1, err2, err3 ])  res
   where
-    err1 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid3\n   ... via templates-nsbind/nsbinderror.tpl: h:main2\nBound splices: h:sub h:recurse h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid3\", elementAttrs = [], elementChildren = []}"
-    err2 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid2\n   ... via templates-nsbind/nsbinderror.tpl: h:recurse\n   ... via templates-nsbind/nsbinderror.tpl: h:main\nBound splices: h:sub h:recurse h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid2\", elementAttrs = [], elementChildren = []}"
-    err3 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid1\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid1\", elementAttrs = [], elementChildren = []}"
+    err1 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid3\n   ... via templates-nsbind/nsbinderror.tpl: h:main2\nBound splices: h:call h:main h:main2 h:recurse h:sub\nNode: Element {elementTag = \"h:invalid3\", elementAttrs = [], elementChildren = []}"
+    err2 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid2\n   ... via templates-nsbind/nsbinderror.tpl: h:recurse\n   ... via templates-nsbind/nsbinderror.tpl: h:main\nBound splices: h:call h:main h:main2 h:recurse h:sub\nNode: Element {elementTag = \"h:invalid2\", elementAttrs = [], elementChildren = []}"
+    err3 = "templates-nsbind/nsbinderror.tpl: No splice bound for h:invalid1\nBound splices: h:call h:main h:main2\nNode: Element {elementTag = \"h:invalid1\", elementAttrs = [], elementChildren = []}"
 
 
 ------------------------------------------------------------------------------
@@ -284,7 +284,7 @@ nsBindStackTest = do
                          , Just "templates-nsbind/nsbinderror.tpl"
                          , "h:main2") ]
                (Just "templates-nsbind/nsbinderror.tpl")
-               ["h:sub","h:recurse","h:call","h:main2","h:main"]
+               ["h:call","h:main","h:main2","h:recurse","h:sub"]
                (X.Element "h:invalid3" [] [])
                "No splice bound for h:invalid3"
     err2 = SpliceError [ ( ["nsbinderror"]
@@ -294,12 +294,12 @@ nsBindStackTest = do
                          , Just "templates-nsbind/nsbinderror.tpl"
                          ,"h:main") ]
                (Just "templates-nsbind/nsbinderror.tpl")
-               ["h:sub","h:recurse","h:call","h:main2","h:main"]
+               ["h:call","h:main","h:main2","h:recurse","h:sub"]
                (X.Element "h:invalid2" [] [])
                "No splice bound for h:invalid2"
     err3 = SpliceError []
                (Just "templates-nsbind/nsbinderror.tpl")
-               ["h:call","h:main2","h:main"]
+               ["h:call","h:main","h:main2"]
                (X.Element "h:invalid1" [] [])
                "No splice bound for h:invalid1"
 
@@ -334,8 +334,8 @@ nsCallErrTest = do
       (Left $ Set.fromList [ err1, err2 ])
       (first Set.fromList res)
   where
-    err1 = "templates-nscall/_call.tpl: No splice bound for h:sub\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:sub\", elementAttrs = [], elementChildren = []}"
-    err2 = "templates-nscall/_invalid.tpl: No splice bound for h:invalid\nBound splices: h:call h:main2 h:main\nNode: Element {elementTag = \"h:invalid\", elementAttrs = [], elementChildren = []}"
+    err1 = "templates-nscall/_call.tpl: No splice bound for h:sub\nBound splices: h:call h:main h:main2\nNode: Element {elementTag = \"h:sub\", elementAttrs = [], elementChildren = []}"
+    err2 = "templates-nscall/_invalid.tpl: No splice bound for h:invalid\nBound splices: h:call h:main h:main2\nNode: Element {elementTag = \"h:invalid\", elementAttrs = [], elementChildren = []}"
 
 
 ------------------------------------------------------------------------------
@@ -357,7 +357,7 @@ exceptionsTest = do
     H.assertEqual "exceptions" (Right (msg, err)) $ res
 
   where
-    msg = "templates-loaderror/_error.tpl: Exception in splice compile: Prelude.read: no parse\n   ... via templates-loaderror/_error.tpl: h:adder\n   ... via templates-loaderror/test.tpl: h:call2\nBound splices: h:adder h:call2 h:call1\nNode: Element {elementTag = \"h:adder\", elementAttrs = [(\"value\",\"noparse\")], elementChildren = []}"
+    msg = "templates-loaderror/_error.tpl: Exception in splice compile: Prelude.read: no parse\n   ... via templates-loaderror/_error.tpl: h:adder\n   ... via templates-loaderror/test.tpl: h:call2\nBound splices: h:adder h:call1 h:call2\nNode: Element {elementTag = \"h:adder\", elementAttrs = [(\"value\",\"noparse\")], elementChildren = []}"
     err = SpliceError [ ( ["test"]
                         , Just "templates-loaderror/_error.tpl"
                         , "h:adder"),
@@ -365,7 +365,7 @@ exceptionsTest = do
                         , Just "templates-loaderror/test.tpl"
                         ,"h:call2") ]
               (Just "templates-loaderror/_error.tpl")
-              ["h:adder", "h:call2", "h:call1"]
+              ["h:adder", "h:call1", "h:call2"]
               (X.Element "h:adder" [("value", "noparse")] [])
               "Exception in splice compile: Prelude.read: no parse"
     hc = HeistConfig sc "h" True


### PR DESCRIPTION
Bump aeson to work with aeson 2.0 (default ordered KeyMap)
It also work with GHC 9.2.1 with configuration  allow-newer: all:all