### PR TITLE
Expose `Heist.Common`

### DIFF
--- a/heist.cabal
+++ b/heist.cabal
@@ -139,6 +139,7 @@ Library
 
   exposed-modules:
     Heist,
+    Heist.Common,
     Heist.Compiled,
     Heist.Compiled.LowLevel,
     Heist.Internal.Types,
@@ -156,7 +157,6 @@ Library
 
   other-modules:
     Data.HeterogeneousEnvironment,
-    Heist.Common,
     Heist.Compiled.Internal,
     Heist.Internal.Types.HeistState,
     Heist.Interpreted.Internal


### PR DESCRIPTION
See #129 for rationale. 

It would be great to have this in next release because then I can retire https://hackage.haskell.org/package/heist-emanote for https://emanote.srid.ca/ can then use official Heist library.

cc @ cydparser