### PR TITLE
Expose `lookupTemplate` and `splitTemplatePath`

### DIFF
--- a/src/Heist.hs
+++ b/src/Heist.hs
@@ -84,6 +84,10 @@ module Heist
   , spliceErrorText
   , orError
   , Splices
+
+  -- * TPath functions
+  , lookupTemplate
+  , splitTemplatePath
   ) where
 
 


### PR DESCRIPTION
These are useful for managing the template file store manually by hand, as is done by the `heist-extra` library (used by https://emanote.srid.ca/).

Rationale: https://github.com/snapframework/heist/pull/138#issuecomment-1311209941

Closes https://github.com/snapframework/heist/issues/129