### PR TITLE
Allow QuickCheck 2.15 and lens 5.3; bump cabal CI to GHC 9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         ghc:
@@ -36,12 +37,13 @@ jobs:
           - "9.4"
           - "9.6"
           - "9.8"
+          - "9.10"
         include:
           - { os: macOS-latest,   ghc: "9.8" }
           - { os: windows-latest, ghc: "9.8" }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up GHC ${{ matrix.ghc-version }}
         uses: haskell-actions/setup@v2
@@ -78,10 +80,11 @@ jobs:
         run: cabal build all
 
       - uses: nikeee/setup-pandoc@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
+
       # Work is needed to get tests to pass on other OSes.
       - name: Test
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: cabal test all
 
       - name: Documentation

--- a/heist.cabal
+++ b/heist.cabal
@@ -36,9 +36,10 @@ tested-with:
   GHC == 8.10.7
   GHC == 9.0.2
   GHC == 9.2.8
-  GHC == 9.4.7
-  GHC == 9.6.3
-  GHC == 9.8.1
+  GHC == 9.4.8
+  GHC == 9.6.5
+  GHC == 9.8.2
+  GHC == 9.10.1
 
 extra-doc-files:
   CHANGELOG.md
@@ -227,8 +228,8 @@ Test-suite testsuite
 
   build-depends:
     HUnit                      >= 1.2      && < 2,
-    QuickCheck                 >= 2        && < 2.15,
-    lens                       >= 4.3      && < 5.3,
+    QuickCheck                 >= 2        && < 2.16,
+    lens                       >= 4.3      && < 5.4,
     test-framework             >= 0.4      && < 0.9,
     test-framework-hunit       >= 0.2.7    && < 0.4,
     test-framework-quickcheck2 >= 0.2.12.1 && < 0.4,


### PR DESCRIPTION
Not sure why CI does not run here.  It runs at: https://github.com/andreasabel/heist/pull/1